### PR TITLE
fix: change importMaps to redirections and other namings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Coming soon:
 Install it globally using yarn or npm
 
 ```js
-npm install -g smartcdn
+npm install -g scdn
 ```
 
 ## Configuration
@@ -35,20 +35,20 @@ The server can be configured using ENV variables and/or using a config file. ENV
 
 ENV variables you can set are: `port`, `packagesFolder` and `uplink`.
 
-The config file should be placed in the folder where the server is being started with `smartcdn.config.js` name. You can set dynamic configuration in this file for different running environments.
+The config file should be placed in the folder where the server is being started with `scdn.config.js` name. You can set dynamic configuration in this file for different running environments.
 
 ```js
 const config = {
   port: 3000,
   packagesFolder: "~/.cdnPackages",
-  importMaps: {
+  redirections: {
     "test@latest": "/test/2.0.0/entryPoint.js",
   },
 };
 
 if (process.env.NODE_ENV === "production") {
   config.port = 4000;
-  config.importMaps["test@latest"] = "/test/1.0.0/entryPoint.js";
+  config.redirections["test@latest"] = "/test/1.0.0/entryPoint.js";
 }
 
 export default config;

--- a/scdn.config.js
+++ b/scdn.config.js
@@ -1,0 +1,8 @@
+export default {
+  redirections: {
+    "ing-feat-layout/1.0.2/gema_application-header.js":
+      "/ing-feat-layout/1.0.1/gema_application-header.js",
+    "router@latest": "/ing-web-es_router/1.8.0/dist-router/interface.js",
+  },
+  port: 3000,
+};

--- a/scdn.config.js.example
+++ b/scdn.config.js.example
@@ -1,5 +1,5 @@
 export default {
-  importMaps: {
+  redirections: {
     router: "/ing-web-es_router/1.8.0/dist-router/interface.js",
   },
   port: 3000,

--- a/src/adapters/ExpressServer.js
+++ b/src/adapters/ExpressServer.js
@@ -18,11 +18,11 @@ export class ExpressServer {
    * Create a new ExpressServer instance with the adapters
    * @param {import('../../types/Server').ServerOptions} adapters
    */
-  constructor({ database, packagesFolder, uplink, importMaps = {} }) {
+  constructor({ database, packagesFolder, uplink, redirections = {} }) {
     this._packagesFolder = packagesFolder;
     this._uplink = uplink;
     this._database = database;
-    this._importMaps = importMaps;
+    this._redirections = redirections;
 
     this._app = express();
     this._app.use(cors());
@@ -45,7 +45,7 @@ export class ExpressServer {
     });
 
     this._app.listen(port, () =>
-      console.log(`Server listening on http://${host}:${port}`)
+      console.log(`SCDN Server listening at http://${host}:${port}`)
     );
   }
 
@@ -89,8 +89,8 @@ export class ExpressServer {
         createUploadPackageMiddleware(this._packagesFolder),
       ],
       staticWithSourceMap: staticWithSourceMap.bind(this),
-      importMaps: importMaps.bind(this),
-      serveImportMaps: serveImportMaps.bind(this),
+      serveRedirections: serveRedirections.bind(this),
+      redirections: redirections.bind(this),
     };
   }
 }
@@ -152,8 +152,8 @@ async function staticWithSourceMap(req, res, next) {
   }
 }
 
-async function importMaps(req, res, next) {
-  const redirection = this._importMaps[req.path.slice(1)];
+async function serveRedirections(req, res, next) {
+  const redirection = this._redirections[req.path.slice(1)];
   if (redirection) {
     console.log(
       `[info]: Redirecting based on import map from ${req.path} to ${redirection} .`
@@ -164,13 +164,13 @@ async function importMaps(req, res, next) {
   }
 }
 
-function serveImportMaps(req, res) {
+function redirections(req, res) {
   const hostAndPort = `http://${this._host}:${this._port}`;
-  const importMaps = Object.keys(this._importMaps).reduce((result, key) => {
-    result[key] = [hostAndPort, this._importMaps[key]].join("");
+  const redirections = Object.keys(this._redirections).reduce((result, key) => {
+    result[key] = [hostAndPort, this._redirections[key]].join("");
     return result;
   }, {});
-  return importMaps;
+  return redirections;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ dotenv.config();
   // Load variables from config file into process.env
   try {
     const configFilePath =
-      process.env.config || path.join(process.cwd(), "smartcdn.config.js");
+      process.env.config || path.join(process.cwd(), "scdn.config.js");
     const config = await import(configFilePath);
     process.env = { ...config.default, ...process.env };
   } catch (error) {}
@@ -32,7 +32,7 @@ dotenv.config();
     database,
     packagesFolder,
     // @ts-ignore
-    importMaps: process.env.importMaps,
+    redirections: process.env.redirections,
   });
 
   const application = createApplication({
@@ -54,13 +54,13 @@ dotenv.config();
     }
   );
   // Import map
-  server.use(server.middlewares.importMaps);
+  server.use(server.middlewares.serveRedirections);
   server.use(server.middlewares.staticWithSourceMap);
   server.static(packagesFolder);
 
   server.static(path.join(process.cwd(), "ui"));
 
-  server.route("/importMaps", server.middlewares.serveImportMaps);
+  server.route("/redirections", server.middlewares.redirections);
   server.route(
     "/api/packages",
     async () => await application.getLastPublishedPackages(10)

--- a/types/Server.d.ts
+++ b/types/Server.d.ts
@@ -18,5 +18,5 @@ export type ServerOptions = {
   database: DatabaseAdapter;
   packagesFolder: string;
   uplink?: string;
-  importMaps?: object;
+  redirections?: object;
 };


### PR DESCRIPTION
As importMaps was confusing, we are using redirections instead.
Config file name changed from smartcdn.config.js to scdn.config.js
Change README with this new naming and name of the package in the install section.