### PR TITLE
feat: use a config file in a different path using the config param

### DIFF
--- a/.changeset/big-books-speak.md
+++ b/.changeset/big-books-speak.md
@@ -1,0 +1,5 @@
+---
+"scdn": minor
+---
+
+use a config file in a different path using the config param

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .env
-smartcdn.config.js
+scdn.config.js

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ This was a personal project that I found useful and I wanted to share it. It bas
 - **SourceMap**: Add a source map header and reference at the end of each file to serve source map files to the browser.
 - **Uplink server**: Fallback server to request files not found in the local one.
 - **ImportMap**: Include redirections for paths.
+- **Cache**: Add long term cache
+- **Config file path**: Point to a config file out of the directory where the server has been started.
 
 Coming soon:
 
-- **Config file path**: Point to a config file out of the directory where the server has been started.
 - **Watch mode**: Auto publish a package every time a file is updated in the folder where the bundled code is dropped.
 - **Web UI**: A web interface to search and inspect published packages and server configuration.
 - **Secure Mode**: The server rejects to override a version already published.
 - **Popular CDNs as uplinks**: Configure the server to use CDNs such as Skypack as uplink using a single option ( --uplink-skypack ).
-- **Cache**: Add long term cache
 
 ## Getting started
 
@@ -39,6 +39,7 @@ The config file should be placed in the folder where the server is being started
 
 ```js
 const config = {
+  host: "my.cdn.com",
   port: 3000,
   packagesFolder: "~/.cdnPackages",
   redirections: {
@@ -62,6 +63,7 @@ The package includes the `scdn` command.
 
 Starts the server with the default configuration. This command has these options:
 
+- -s, --host: The host name to be used in urls pointing to the server. [default: localhost]
 - -p, --port: The port the server will be listening to. [default: 3000]
 - -f, --packagesFolder: The path to the folder where the packages are/will be stored. [default: <USER_HOME>/.scdn]
 - -u, --uplink: The first URL section of the server to be used as fallback. For example: https://uplink.cdn.com . [default: none]
@@ -72,9 +74,9 @@ Examples:
 ```bash
 > scdn start
 
-> scdn start -p 3001 -f /packages -u https://uplink.cdn.com
+> scdn start -n my.cdn.com -p 3001 -f /packages -u https://uplink.cdn.com
 
-> scdn start --port 3001 --packagesFolder /packages --uplink https://uplink.cdn.com
+> scdn start --host my.cdn.com --port 3001 --packagesFolder /packages --uplink https://uplink.cdn.com
 ```
 
 > scdn publish

--- a/bin/scdn.cjs
+++ b/bin/scdn.cjs
@@ -28,6 +28,9 @@ const ONE_CDN_FOLDER = ".scdn";
       args.readmePath || process.env.readmePath || "./README.md";
     const packagePath =
       args.packgePath || process.env.packagePath || "./package.json";
+    const config = parseFolder(
+      args.config || process.env.config || "scdn.config.js"
+    );
 
     return {
       host,
@@ -36,6 +39,7 @@ const ONE_CDN_FOLDER = ".scdn";
       sourceFolder,
       readmePath,
       packagePath,
+      config,
     };
   }
 
@@ -46,8 +50,15 @@ const ONE_CDN_FOLDER = ".scdn";
   }
 
   /** @type {import("../types/Options").CommandLineOptions} */
-  const { host, port, packagesFolder, sourceFolder, readmePath, packagePath } =
-    parseOptions();
+  const {
+    host,
+    port,
+    packagesFolder,
+    sourceFolder,
+    readmePath,
+    packagePath,
+    config,
+  } = parseOptions();
 
   const argv = yargs(hideBin(process.argv))
     .usage("$0 <command> [options]")
@@ -55,21 +66,29 @@ const ONE_CDN_FOLDER = ".scdn";
       "start",
       "Start the CDN server.",
       {
+        host: {
+          alias: "s",
+          description: "Host name where the server is hosted",
+          default: host,
+        },
         port: {
           alias: "p",
           description: "Port number where the host will be listening.",
-          default: port,
         },
         packagesFolder: {
           alias: "f",
           description:
             "Absolute path to the folder that will be used to store the files.",
-          default: packagesFolder,
         },
         uplink: {
           alias: "u",
           description:
             "The host name to be used as fallback to request files from.",
+        },
+        config: {
+          alias: "c",
+          description: "Path of the config file",
+          default: config,
         },
       },
       start
@@ -81,13 +100,13 @@ const ONE_CDN_FOLDER = ".scdn";
         host: {
           alias: "s",
           type: "string",
-          description: "host hostname or IP",
+          description: "Server's hostname or IP",
           default: host,
         },
         port: {
           alias: "p",
           type: "number",
-          description: "Port number where the host is listening",
+          description: "Port number where the server is listening at",
           default: port,
         },
         folder: {
@@ -114,13 +133,14 @@ const ONE_CDN_FOLDER = ".scdn";
     .help("h").argv;
 
   function start(args) {
-    const { port, packagesFolder, uplink } = args;
+    const { port, packagesFolder, uplink, config } = args;
     const child = spawn("node", [path.join(__dirname, "..", "src/index.js")], {
       env: {
         PATH: process.env.PATH,
         port,
         packagesFolder,
         uplink,
+        config,
       },
     });
 

--- a/scdn.config.js
+++ b/scdn.config.js
@@ -4,5 +4,6 @@ export default {
       "/ing-feat-layout/1.0.1/gema_application-header.js",
     "router@latest": "/ing-web-es_router/1.8.0/dist-router/interface.js",
   },
-  port: 3000,
+  port: 3002,
+  host: "my.cdn.com",
 };

--- a/scdn.config.js.example
+++ b/scdn.config.js.example
@@ -1,7 +1,8 @@
 export default {
+  host: 'my.cdn.com',
+  port: 3000,
   redirections: {
     router: "/ing-web-es_router/1.8.0/dist-router/interface.js",
   },
-  port: 3000,
-  packagesFolder: "~/.cdnPackages",
+  packagesFolder: "~/.cdn-packages",
 };

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,14 @@ dotenv.config();
 
 (async () => {
   // Load variables from config file into process.env
+  console.log(process.env);
   try {
     const configFilePath =
       process.env.config || path.join(process.cwd(), "scdn.config.js");
     const config = await import(configFilePath);
+
+    console.log("## Using config file", configFilePath);
+
     process.env = { ...config.default, ...process.env };
   } catch (error) {}
 
@@ -25,6 +29,11 @@ dotenv.config();
     uplink: uplinkHost,
     host = "localhost",
   } = process.env;
+
+  console.log("## Host name:", host);
+  console.log("## Port:", port);
+  console.log("## Packages folder:", packagesFolder);
+  if (uplinkHost) console.log("## Uplink:", uplinkHost);
 
   const database = new MemoryDatabase();
   const uplink = uplinkHost && new GenericUplink(uplinkHost);

--- a/types/Options.d.ts
+++ b/types/Options.d.ts
@@ -6,4 +6,5 @@ export type CommandLineOptions = {
   readmePath: string;
   packagePath: string;
   uplink?: string;
+  config?: string;
 };


### PR DESCRIPTION
- add -c --config argument to CLI.
- add -n --host argument to serve command.
- read the config from the value passed in config argument.
- add config parameter to start output.