### PR TITLE
feat: add secure mode to start command

### DIFF
--- a/.changeset/tough-turkeys-divide.md
+++ b/.changeset/tough-turkeys-divide.md
@@ -1,0 +1,5 @@
+---
+"scdn": minor
+---
+
+add secure mode flag to `start` command ( -s, --secure)

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This was a personal project that I found useful and I wanted to share it. It bas
 - **Cache**: Add long term cache
 - **Config file path**: Point to a config file out of the directory where the server has been started.
 - **Watch mode**: Auto publish a package every time a file is updated in the folder where the bundled code is dropped.
+- **Secure Mode**: The server rejects to override a version already published.
 
 Coming soon:
 
 - **Web UI**: A web interface to search and inspect published packages and server configuration.
-- **Secure Mode**: The server rejects to override a version already published.
 - **Popular CDNs as uplinks**: Configure the server to use CDNs such as Skypack as uplink using a single option ( --uplink-skypack ).
 
 ## Getting started
@@ -63,10 +63,11 @@ The package includes the `scdn` command.
 
 Starts the server with the default configuration. This command has these options:
 
-- -s, --host: The host name to be used in urls pointing to the server. [default: localhost]
+- -n, --host: The host name to be used in urls pointing to the server. [default: localhost]
 - -p, --port: The port the server will be listening to. [default: 3000]
 - -f, --packagesFolder: The path to the folder where the packages are/will be stored. [default: <USER_HOME>/.scdn]
 - -u, --uplink: The first URL section of the server to be used as fallback. For example: https://uplink.cdn.com . [default: none]
+- -s, --secure: Run the server in secure mode. In secure mode, publishing the same version of a package is forbiden. [default: false]
 - -h: Print this help.
 
 Examples:
@@ -74,9 +75,9 @@ Examples:
 ```bash
 > scdn start
 
-> scdn start -n my.cdn.com -p 3001 -f /packages -u https://uplink.cdn.com
+> scdn start -s -n my.cdn.com -p 3001 -f /packages -u https://uplink.cdn.com
 
-> scdn start --host my.cdn.com --port 3001 --packagesFolder /packages --uplink https://uplink.cdn.com
+> scdn start --secure --host my.cdn.com --port 3001 --packagesFolder /packages --uplink https://uplink.cdn.com
 ```
 
 > scdn publish
@@ -84,7 +85,7 @@ Examples:
 Publish a package to the server. The dist folder, package.json and README.md files are pushed to the server and stored. If you are not in the root of the package, or the dist folder is different, or the server is in a different machine, you can configure the options.
 
 - -p, --port: Port number where the server is listening to. [default: 3000]
-- -s, --host: host name or ip where the server is hosted. [default: localhost]
+- -n, --host: host name or ip where the server is hosted. [default: localhost]
 - -f, --folder: path to the folder where the the content to publish is placed. [default: ./dist]
 - -r, --readme: Path to the README.md to include [default: ./REAME.md]
 - -i, --package: Path to re package.json to include. [default: ./package.json]
@@ -96,7 +97,7 @@ Examples:
 ```bash
 > scdn publish
 
-> scdn -s 192.168.0.1 -p 3001 -f /packages/todo/bundle -r /packages/todo/README.md -i /pacakges/todo/package.json
+> scdn -n 192.168.0.1 -p 3001 -f /packages/todo/bundle -r /packages/todo/README.md -i /pacakges/todo/package.json
 
 > scdn publish -w
 ```

--- a/bin/scdn.cjs
+++ b/bin/scdn.cjs
@@ -32,6 +32,7 @@ const ONE_CDN_FOLDER = ".scdn";
       args.config || process.env.config || "scdn.config.js"
     );
     const watch = args.watch || process.env.watch;
+    const secure = args.secure || process.env.secure;
 
     return {
       host,
@@ -42,6 +43,7 @@ const ONE_CDN_FOLDER = ".scdn";
       packagePath,
       config,
       watch,
+      secure,
     };
   }
 
@@ -52,7 +54,7 @@ const ONE_CDN_FOLDER = ".scdn";
   }
 
   /** @type {import("../types/Options").CommandLineOptions} */
-  const { host, port, sourceFolder, readmePath, packagePath, config } =
+  const { host, port, sourceFolder, readmePath, packagePath, config, secure } =
     parseOptions();
 
   const argv = yargs(hideBin(process.argv))
@@ -62,7 +64,7 @@ const ONE_CDN_FOLDER = ".scdn";
       "Start the CDN server.",
       {
         host: {
-          alias: "s",
+          alias: "n",
           description: "Host name where the server is hosted",
           default: host,
         },
@@ -85,6 +87,10 @@ const ONE_CDN_FOLDER = ".scdn";
           description: "Path of the config file",
           default: config,
         },
+        secure: {
+          alias: "s",
+          description: "Run server in secure mode.",
+        },
       },
       start
     )
@@ -93,7 +99,7 @@ const ONE_CDN_FOLDER = ".scdn";
       "Publish a package to the CDN host.",
       {
         host: {
-          alias: "s",
+          alias: "n",
           type: "string",
           description: "Server's hostname or IP",
           default: host,
@@ -134,7 +140,7 @@ const ONE_CDN_FOLDER = ".scdn";
     .help("h").argv;
 
   function start(args) {
-    const { port, packagesFolder, uplink, config } = args;
+    const { port, packagesFolder, uplink, config, secure } = args;
     const child = spawn("node", [path.join(__dirname, "..", "src/index.js")], {
       env: {
         PATH: process.env.PATH,
@@ -142,6 +148,7 @@ const ONE_CDN_FOLDER = ".scdn";
         packagesFolder,
         uplink,
         config,
+        secure,
       },
     });
 

--- a/scdn.config.js
+++ b/scdn.config.js
@@ -1,9 +1,15 @@
+import os from "node:os";
+import path from "node:path";
+
 export default {
   redirections: {
     "ing-feat-layout/1.0.2/gema_application-header.js":
       "/ing-feat-layout/1.0.1/gema_application-header.js",
     "router@latest": "/ing-web-es_router/1.8.0/dist-router/interface.js",
   },
-  port: 3002,
-  host: "my.cdn.com",
+  port: 3000,
+  host: "localhost",
+  secure: true,
+  packagesFolder: path.join(os.homedir(), ".scdn"),
+  uplink: "https://cdnjs.cloudflare.com/ajax/libs/",
 };

--- a/src/adapters/ExpressServer.js
+++ b/src/adapters/ExpressServer.js
@@ -18,11 +18,12 @@ export class ExpressServer {
    * Create a new ExpressServer instance with the adapters
    * @param {import('../../types/Server').ServerOptions} adapters
    */
-  constructor({ database, packagesFolder, uplink, redirections = {} }) {
+  constructor({ database, packagesFolder, uplink, secure, redirections = {} }) {
     this._packagesFolder = packagesFolder;
     this._uplink = uplink;
     this._database = database;
     this._redirections = redirections;
+    this._secure = Boolean(secure);
 
     this._app = express();
     this._app.use(cors());
@@ -36,12 +37,20 @@ export class ExpressServer {
     return this._packagesFolder;
   }
 
+  get secure() {
+    return this._secure;
+  }
+
   start(host, port) {
     this._host = host;
     this._port = port;
 
     this._app.get("*", (req, res) => {
-      res.sendFile(path.join("ui/index.html"));
+      const { pathname: root } = new URL(
+        "../../ui/index.html",
+        import.meta.url
+      );
+      res.sendFile(root);
     });
 
     this._app.listen(port, () =>

--- a/src/adapters/MemoryDatabase.js
+++ b/src/adapters/MemoryDatabase.js
@@ -37,4 +37,8 @@ export class MemoryDatabase {
   values() {
     return Promise.resolve(Object.values(this._data));
   }
+
+  async exist(key) {
+    return Promise.resolve((await this.keys()).includes(key));
+  }
 }

--- a/src/application.js
+++ b/src/application.js
@@ -38,7 +38,7 @@ export function createApplication({ database, server, uplink }) {
     async getPackageVersion(name, version) {
       const packageInfo = await database.get(databaseKey({ name, version }));
       if (!packageInfo)
-        throw Error(`[error]: No info in database for ${name}@${version} .`);
+        throw Error(`## [Error]: No info in database for ${name}@${version} .`);
       return new Package(packageInfo);
     },
     async getSemverVersion(name, version) {
@@ -51,12 +51,18 @@ export function createApplication({ database, server, uplink }) {
         return _version;
       }
     },
-    savePackage(info) {
+    async savePackage(info) {
+      const key = databaseKey(info);
+      if (server.secure && (await database.exist(key))) {
+        throw Error(
+          "## [Error]: Packages cannot be overwritten in secure mode."
+        );
+      }
       database.set(databaseKey(info), info);
     },
 
     async getFileFromUplink({ name, version, file }) {
-      if (!uplink) throw Error();
+      if (!uplink) throw Error("## [Error]: No uplink provided.");
 
       const packageName = uplink.parseScopedName(name);
       const content = await uplink.get({ name, version, file });

--- a/src/domain/PackageName.js
+++ b/src/domain/PackageName.js
@@ -1,0 +1,38 @@
+export class PackageName {
+  /**
+   * Creates a new instance of PackageName
+   *
+   * @param {object} values
+   * @param {string} [values.scope];
+   * @param {string} values.name;
+   * @param {string} [values.version];
+   */
+  constructor({ scope, name, version }) {
+    if (!scope) {
+      const { scope: _scope, name: _name } =
+        PackageName.extractScopeAndName(name);
+      this._scope = _scope;
+      this._name = _name;
+    } else {
+      this._scope = scope;
+      this._name = name;
+    }
+    this._version = version;
+  }
+
+  get name() {
+    return this._scope ? ["@" + this._scope, this._name].join("/") : this._name;
+  }
+
+  get version() {
+    return this._version;
+  }
+
+  static extractScopeAndName(text = "") {
+    if (text.startsWith("@")) {
+      const [scope, name] = text.split("/");
+      return { scope: scope.slice(1), name };
+    }
+    return { name: text };
+  }
+}

--- a/types/Database.d.ts
+++ b/types/Database.d.ts
@@ -5,4 +5,5 @@ export interface DatabaseAdapter {
   delete(key: string);
   keys(): Promise<string[]>;
   values(): Promise<object[]>;
+  exist(key: string): Promise<boolean>;
 }

--- a/types/Server.d.ts
+++ b/types/Server.d.ts
@@ -18,5 +18,6 @@ export type ServerOptions = {
   database: DatabaseAdapter;
   packagesFolder: string;
   uplink?: string;
+  secure?: boolean;
   redirections?: object;
 };


### PR DESCRIPTION
- Added secure mode to start command behind -s, --secure flag
- Renamed shorthand flag for hostname from -s to -n
- Added PackageName domain class to control package names with scope, name, and version.
- Fixed serving root UI HTML when the server is started from any location. 

When the server is started in secure mode, if a specific version of a package is present, it can't be overwritten.